### PR TITLE
Fix typo on the storage_gui user/password to pass in the correct one

### DIFF
--- a/roles/core/remote_mount/tasks/mount_filesystem.yml
+++ b/roles/core/remote_mount/tasks/mount_filesystem.yml
@@ -123,8 +123,8 @@
     force_basic_auth: true
     url: https://{{ storage_cluster_hostname }}:{{ storage_gui_port }}/{{ remote_mount_endpoint }}/remoteclusters
     method: POST
-    user: "{{ client_gui_user }}"
-    password: "{{ client_gui_password }}"
+    user: "{{ storage_gui_user }}"
+    password: "{{ storage_gui_password }}"
     body_format: json
     body: |
       {
@@ -141,8 +141,8 @@
     force_basic_auth: true
     url: https://{{ storage_cluster_hostname }}:{{ storage_gui_port }}/{{ scalemgmt_endpoint }}/jobs/{{ send_key.json.jobs[0].jobId }}
     method: GET
-    user: "{{ client_gui_user }}"
-    password: "{{ client_gui_password }}"
+    user: "{{ storage_gui_user }}"
+    password: "{{ storage_gui_password }}"
   register: completed_check
   until: completed_check.json.jobs[0].status != "FAILED"
   retries: "{{ restapi_retries_count }}"


### PR DESCRIPTION
As part of the testing going on, a reported bug was found where the storage_gui_user/password was not being used hitting the storage endpoint. 

Before the  fix, we see the bad lines 
```bash
Victors-MBP-2:tasks vhu$ grep -A3 storage_cluster *.yml | egrep -v "storage_gui_|method"
--
--
--
--
mount_filesystem.yml-    user: "{{ client_gui_user }}"
mount_filesystem.yml-    password: "{{ client_gui_password }}"
--
mount_filesystem.yml-    user: "{{ client_gui_user }}"
mount_filesystem.yml-    password: "{{ client_gui_password }}"
--
--
--
--
--
precheck.yml:- name: "fail if not defined: storage_cluster_hostname"
precheck.yml-  fail:
precheck.yml:    msg: "storage_cluster_hostname is not defined"
precheck.yml:  when: storage_cluster_hostname is undefined
precheck.yml-
precheck.yml-- name: "fail if not defined: storage_filesystem_name"
precheck.yml-  fail:
Victors-MBP-2:tasks vhu$
```

And just making sure `client_storage` doesn't have the same issue, running a similar grep command

```bash
Victors-MBP-2:tasks vhu$ grep -A3 client_cluster *.yml | egrep -v "client_gui_|method"
--
--
--
--
--
--
--
--
--
--
--
--
--
--
--
--
--
--
precheck.yml:- name: "fail if not defined: client_cluster_hostname"
precheck.yml-  fail:
precheck.yml:    msg: "client_cluster_hostname is not defined"
precheck.yml:  when: client_cluster_hostname is undefined
precheck.yml-
precheck.yml-- name: "fail if not defined: client_filesystem_name"
precheck.yml-  fail:
Victors-MBP-2:tasks vhu$ 
```

And after the fix... 

```bash
Victors-MBP-2:tasks vhu$ grep -A3 storage_cluster *.yml | egrep -v "storage_gui_|method" 
--
--
--
--
--
--
--
--
--
--
precheck.yml:- name: "fail if not defined: storage_cluster_hostname"
precheck.yml-  fail:
precheck.yml:    msg: "storage_cluster_hostname is not defined"
precheck.yml:  when: storage_cluster_hostname is undefined
precheck.yml-
precheck.yml-- name: "fail if not defined: storage_filesystem_name"
precheck.yml-  fail:
```