### PR TITLE
Create more unique names for the remote mount variables

### DIFF
--- a/roles/core/remote_mount/defaults/main.yml
+++ b/roles/core/remote_mount/defaults/main.yml
@@ -7,8 +7,8 @@ forceRun: false
 restapi_retries_count: 36
 restapi_retries_delay: 5
 
-client_gui_port: 443
-storage_gui_port: 443
+client_cluster_gui_port: 443
+storage_cluster_gui_port: 443
 
 scalemgmt_endpoint: "scalemgmt/v2"
 remote_mount_endpoint: "{{ scalemgmt_endpoint }}/remotemount"

--- a/roles/core/remote_mount/tasks/cleanup_filesystem.yml
+++ b/roles/core/remote_mount/tasks/cleanup_filesystem.yml
@@ -3,7 +3,7 @@
   uri:
     validate_certs: no
     force_basic_auth: yes
-    url: https://{{ client_cluster_gui_hostname }}:{{ client_cluster_gui_port }}/{{ remote_mount_endpoint }}/remotefilesystems/{{ client_filesystem_name }}
+    url: https://{{ client_cluster_gui_hostname }}:{{ client_cluster_gui_port }}/{{ remote_mount_endpoint }}/remotefilesystems/{{ client_cluster_filesystem_name }}
     method: GET
     user: "{{ client_cluster_gui_username }}"
     password: "{{ client_cluster_gui_password }}"
@@ -15,11 +15,11 @@
 
 - name: Cleanup | Client Cluster (access) | Remove defined filesystem
   block:
-    - name: "Client Cluster (access) | Unmount the filesystem | PUT {{ scalemgmt_endpoint }}/filesystems/{{ client_filesystem_name }}/unmount"
+    - name: "Client Cluster (access) | Unmount the filesystem | PUT {{ scalemgmt_endpoint }}/filesystems/{{ client_cluster_filesystem_name }}/unmount"
       uri:
         validate_certs: no
         force_basic_auth: true
-        url: https://{{ client_cluster_gui_hostname }}:{{ client_cluster_gui_port }}/{{ scalemgmt_endpoint }}/filesystems/{{ client_filesystem_name }}/unmount
+        url: https://{{ client_cluster_gui_hostname }}:{{ client_cluster_gui_port }}/{{ scalemgmt_endpoint }}/filesystems/{{ client_cluster_filesystem_name }}/unmount
         method: PUT
         user: "{{ client_cluster_gui_username }}"
         password: "{{ client_cluster_gui_password }}"
@@ -45,11 +45,11 @@
       retries: "{{ restapi_retries_count }}"
       delay: "{{ restapi_retries_delay }}"
 
-    - name: "Client Cluster (access) | Delete the filesystem | DELETE: {{ remote_mount_endpoint }}/remotefilesystems/{{ client_filesystem_name }}?force=yes"
+    - name: "Client Cluster (access) | Delete the filesystem | DELETE: {{ remote_mount_endpoint }}/remotefilesystems/{{ client_cluster_filesystem_name }}?force=yes"
       uri:
         validate_certs: no
         force_basic_auth: true
-        url: https://{{ client_cluster_gui_hostname }}:{{ client_cluster_gui_port }}/{{ remote_mount_endpoint }}/remotefilesystems/{{ client_filesystem_name }}?force=yes
+        url: https://{{ client_cluster_gui_hostname }}:{{ client_cluster_gui_port }}/{{ remote_mount_endpoint }}/remotefilesystems/{{ client_cluster_filesystem_name }}?force=yes
         method: DELETE
         user: "{{ client_cluster_gui_username }}"
         password: "{{ client_cluster_gui_password }}"

--- a/roles/core/remote_mount/tasks/cleanup_filesystem.yml
+++ b/roles/core/remote_mount/tasks/cleanup_filesystem.yml
@@ -3,7 +3,7 @@
   uri:
     validate_certs: no
     force_basic_auth: yes
-    url: https://{{ client_cluster_hostname }}:{{ client_cluster_gui_port }}/{{ remote_mount_endpoint }}/remotefilesystems/{{ client_filesystem_name }}
+    url: https://{{ client_cluster_gui_hostname }}:{{ client_cluster_gui_port }}/{{ remote_mount_endpoint }}/remotefilesystems/{{ client_filesystem_name }}
     method: GET
     user: "{{ client_cluster_gui_username }}"
     password: "{{ client_cluster_gui_password }}"
@@ -19,7 +19,7 @@
       uri:
         validate_certs: no
         force_basic_auth: true
-        url: https://{{ client_cluster_hostname }}:{{ client_cluster_gui_port }}/{{ scalemgmt_endpoint }}/filesystems/{{ client_filesystem_name }}/unmount
+        url: https://{{ client_cluster_gui_hostname }}:{{ client_cluster_gui_port }}/{{ scalemgmt_endpoint }}/filesystems/{{ client_filesystem_name }}/unmount
         method: PUT
         user: "{{ client_cluster_gui_username }}"
         password: "{{ client_cluster_gui_password }}"
@@ -36,7 +36,7 @@
       uri:
         validate_certs: no
         force_basic_auth: true
-        url: https://{{ client_cluster_hostname }}:{{ client_cluster_gui_port }}/{{ scalemgmt_endpoint }}/jobs/{{ umount_call.json.jobs[0].jobId }}
+        url: https://{{ client_cluster_gui_hostname }}:{{ client_cluster_gui_port }}/{{ scalemgmt_endpoint }}/jobs/{{ umount_call.json.jobs[0].jobId }}
         method: GET
         user: "{{ client_cluster_gui_username }}"
         password: "{{ client_cluster_gui_password }}"
@@ -49,7 +49,7 @@
       uri:
         validate_certs: no
         force_basic_auth: true
-        url: https://{{ client_cluster_hostname }}:{{ client_cluster_gui_port }}/{{ remote_mount_endpoint }}/remotefilesystems/{{ client_filesystem_name }}?force=yes
+        url: https://{{ client_cluster_gui_hostname }}:{{ client_cluster_gui_port }}/{{ remote_mount_endpoint }}/remotefilesystems/{{ client_filesystem_name }}?force=yes
         method: DELETE
         user: "{{ client_cluster_gui_username }}"
         password: "{{ client_cluster_gui_password }}"
@@ -61,7 +61,7 @@
       uri:
         validate_certs: no
         force_basic_auth: true
-        url: https://{{ client_cluster_hostname }}:{{ client_cluster_gui_port }}/{{ scalemgmt_endpoint }}/jobs/{{ delete_call.json.jobs[0].jobId }}
+        url: https://{{ client_cluster_gui_hostname }}:{{ client_cluster_gui_port }}/{{ scalemgmt_endpoint }}/jobs/{{ delete_call.json.jobs[0].jobId }}
         method: GET
         user: "{{ client_cluster_gui_username }}"
         password: "{{ client_cluster_gui_password }}"

--- a/roles/core/remote_mount/tasks/cleanup_filesystem.yml
+++ b/roles/core/remote_mount/tasks/cleanup_filesystem.yml
@@ -5,8 +5,8 @@
     force_basic_auth: yes
     url: https://{{ client_cluster_hostname }}:{{ client_cluster_gui_port }}/{{ remote_mount_endpoint }}/remotefilesystems/{{ client_filesystem_name }}
     method: GET
-    user: "{{ client_gui_user }}"
-    password: "{{ client_gui_password }}"
+    user: "{{ client_cluster_gui_username }}"
+    password: "{{ client_cluster_gui_password }}"
     body_format: json
     status_code:
       - 200
@@ -21,8 +21,8 @@
         force_basic_auth: true
         url: https://{{ client_cluster_hostname }}:{{ client_cluster_gui_port }}/{{ scalemgmt_endpoint }}/filesystems/{{ client_filesystem_name }}/unmount
         method: PUT
-        user: "{{ client_gui_user }}"
-        password: "{{ client_gui_password }}"
+        user: "{{ client_cluster_gui_username }}"
+        password: "{{ client_cluster_gui_password }}"
         body_format: json
         body: |
           {
@@ -38,8 +38,8 @@
         force_basic_auth: true
         url: https://{{ client_cluster_hostname }}:{{ client_cluster_gui_port }}/{{ scalemgmt_endpoint }}/jobs/{{ umount_call.json.jobs[0].jobId }}
         method: GET
-        user: "{{ client_gui_user }}"
-        password: "{{ client_gui_password }}"
+        user: "{{ client_cluster_gui_username }}"
+        password: "{{ client_cluster_gui_password }}"
       register: completed_check
       until: completed_check.json.jobs[0].status == "COMPLETED"
       retries: "{{ restapi_retries_count }}"
@@ -51,8 +51,8 @@
         force_basic_auth: true
         url: https://{{ client_cluster_hostname }}:{{ client_cluster_gui_port }}/{{ remote_mount_endpoint }}/remotefilesystems/{{ client_filesystem_name }}?force=yes
         method: DELETE
-        user: "{{ client_gui_user }}"
-        password: "{{ client_gui_password }}"
+        user: "{{ client_cluster_gui_username }}"
+        password: "{{ client_cluster_gui_password }}"
         status_code:
           - 202
       register: delete_call
@@ -63,8 +63,8 @@
         force_basic_auth: true
         url: https://{{ client_cluster_hostname }}:{{ client_cluster_gui_port }}/{{ scalemgmt_endpoint }}/jobs/{{ delete_call.json.jobs[0].jobId }}
         method: GET
-        user: "{{ client_gui_user }}"
-        password: "{{ client_gui_password }}"
+        user: "{{ client_cluster_gui_username }}"
+        password: "{{ client_cluster_gui_password }}"
       register: completed_check
       until: completed_check.json.jobs[0].status == "COMPLETED"
       retries: "{{ restapi_retries_count }}"

--- a/roles/core/remote_mount/tasks/cleanup_filesystem.yml
+++ b/roles/core/remote_mount/tasks/cleanup_filesystem.yml
@@ -3,7 +3,7 @@
   uri:
     validate_certs: no
     force_basic_auth: yes
-    url: https://{{ client_cluster_hostname }}:{{ client_gui_port }}/{{ remote_mount_endpoint }}/remotefilesystems/{{ client_filesystem_name }}
+    url: https://{{ client_cluster_hostname }}:{{ client_cluster_gui_port }}/{{ remote_mount_endpoint }}/remotefilesystems/{{ client_filesystem_name }}
     method: GET
     user: "{{ client_gui_user }}"
     password: "{{ client_gui_password }}"
@@ -19,7 +19,7 @@
       uri:
         validate_certs: no
         force_basic_auth: true
-        url: https://{{ client_cluster_hostname }}:{{ client_gui_port }}/{{ scalemgmt_endpoint }}/filesystems/{{ client_filesystem_name }}/unmount
+        url: https://{{ client_cluster_hostname }}:{{ client_cluster_gui_port }}/{{ scalemgmt_endpoint }}/filesystems/{{ client_filesystem_name }}/unmount
         method: PUT
         user: "{{ client_gui_user }}"
         password: "{{ client_gui_password }}"
@@ -36,7 +36,7 @@
       uri:
         validate_certs: no
         force_basic_auth: true
-        url: https://{{ client_cluster_hostname }}:{{ client_gui_port }}/{{ scalemgmt_endpoint }}/jobs/{{ umount_call.json.jobs[0].jobId }}
+        url: https://{{ client_cluster_hostname }}:{{ client_cluster_gui_port }}/{{ scalemgmt_endpoint }}/jobs/{{ umount_call.json.jobs[0].jobId }}
         method: GET
         user: "{{ client_gui_user }}"
         password: "{{ client_gui_password }}"
@@ -49,7 +49,7 @@
       uri:
         validate_certs: no
         force_basic_auth: true
-        url: https://{{ client_cluster_hostname }}:{{ client_gui_port }}/{{ remote_mount_endpoint }}/remotefilesystems/{{ client_filesystem_name }}?force=yes
+        url: https://{{ client_cluster_hostname }}:{{ client_cluster_gui_port }}/{{ remote_mount_endpoint }}/remotefilesystems/{{ client_filesystem_name }}?force=yes
         method: DELETE
         user: "{{ client_gui_user }}"
         password: "{{ client_gui_password }}"
@@ -61,7 +61,7 @@
       uri:
         validate_certs: no
         force_basic_auth: true
-        url: https://{{ client_cluster_hostname }}:{{ client_gui_port }}/{{ scalemgmt_endpoint }}/jobs/{{ delete_call.json.jobs[0].jobId }}
+        url: https://{{ client_cluster_hostname }}:{{ client_cluster_gui_port }}/{{ scalemgmt_endpoint }}/jobs/{{ delete_call.json.jobs[0].jobId }}
         method: GET
         user: "{{ client_gui_user }}"
         password: "{{ client_gui_password }}"

--- a/roles/core/remote_mount/tasks/delete_remote_cluster.yml
+++ b/roles/core/remote_mount/tasks/delete_remote_cluster.yml
@@ -3,7 +3,7 @@
   uri:
     validate_certs: no
     force_basic_auth: true
-    url: https://{{ client_cluster_hostname }}:{{ client_gui_port }}/{{ remote_mount_endpoint }}/owningclusters/{{ owning_cluster_name }}
+    url: https://{{ client_cluster_hostname }}:{{ client_cluster_gui_port }}/{{ remote_mount_endpoint }}/owningclusters/{{ owning_cluster_name }}
     method: DELETE
     user: "{{ client_gui_user }}"
     password: "{{ client_gui_password }}"
@@ -15,7 +15,7 @@
   uri:
     validate_certs: no
     force_basic_auth: true
-    url: https://{{ client_cluster_hostname }}:{{ client_gui_port }}/{{ scalemgmt_endpoint }}/jobs/{{ delete_call.json.jobs[0].jobId }}
+    url: https://{{ client_cluster_hostname }}:{{ client_cluster_gui_port }}/{{ scalemgmt_endpoint }}/jobs/{{ delete_call.json.jobs[0].jobId }}
     method: GET
     user: "{{ client_gui_user }}"
     password: "{{ client_gui_password }}"

--- a/roles/core/remote_mount/tasks/delete_remote_cluster.yml
+++ b/roles/core/remote_mount/tasks/delete_remote_cluster.yml
@@ -5,8 +5,8 @@
     force_basic_auth: true
     url: https://{{ client_cluster_hostname }}:{{ client_cluster_gui_port }}/{{ remote_mount_endpoint }}/owningclusters/{{ owning_cluster_name }}
     method: DELETE
-    user: "{{ client_gui_user }}"
-    password: "{{ client_gui_password }}"
+    user: "{{ client_cluster_gui_username }}"
+    password: "{{ client_cluster_gui_password }}"
     status_code:
       - 202
   register: delete_call
@@ -17,8 +17,8 @@
     force_basic_auth: true
     url: https://{{ client_cluster_hostname }}:{{ client_cluster_gui_port }}/{{ scalemgmt_endpoint }}/jobs/{{ delete_call.json.jobs[0].jobId }}
     method: GET
-    user: "{{ client_gui_user }}"
-    password: "{{ client_gui_password }}"
+    user: "{{ client_cluster_gui_username }}"
+    password: "{{ client_cluster_gui_password }}"
   register: completed_check
   until: completed_check.json.jobs[0].status == "COMPLETED"
   retries: "{{ restapi_retries_count }}"

--- a/roles/core/remote_mount/tasks/delete_remote_cluster.yml
+++ b/roles/core/remote_mount/tasks/delete_remote_cluster.yml
@@ -3,7 +3,7 @@
   uri:
     validate_certs: no
     force_basic_auth: true
-    url: https://{{ client_cluster_hostname }}:{{ client_cluster_gui_port }}/{{ remote_mount_endpoint }}/owningclusters/{{ owning_cluster_name }}
+    url: https://{{ client_cluster_gui_hostname }}:{{ client_cluster_gui_port }}/{{ remote_mount_endpoint }}/owningclusters/{{ owning_cluster_name }}
     method: DELETE
     user: "{{ client_cluster_gui_username }}"
     password: "{{ client_cluster_gui_password }}"
@@ -15,7 +15,7 @@
   uri:
     validate_certs: no
     force_basic_auth: true
-    url: https://{{ client_cluster_hostname }}:{{ client_cluster_gui_port }}/{{ scalemgmt_endpoint }}/jobs/{{ delete_call.json.jobs[0].jobId }}
+    url: https://{{ client_cluster_gui_hostname }}:{{ client_cluster_gui_port }}/{{ scalemgmt_endpoint }}/jobs/{{ delete_call.json.jobs[0].jobId }}
     method: GET
     user: "{{ client_cluster_gui_username }}"
     password: "{{ client_cluster_gui_password }}"

--- a/roles/core/remote_mount/tasks/main.yml
+++ b/roles/core/remote_mount/tasks/main.yml
@@ -8,7 +8,7 @@
   uri:
     validate_certs: no
     force_basic_auth: yes
-    url: https://{{ client_cluster_hostname }}:{{ client_gui_port }}/{{ remote_mount_endpoint }}/remotefilesystems/{{ client_filesystem_name }}
+    url: https://{{ client_cluster_hostname }}:{{ client_cluster_gui_port }}/{{ remote_mount_endpoint }}/remotefilesystems/{{ client_filesystem_name }}
     method: GET
     user: "{{ client_gui_user }}"
     password: "{{ client_gui_password }}"

--- a/roles/core/remote_mount/tasks/main.yml
+++ b/roles/core/remote_mount/tasks/main.yml
@@ -8,7 +8,7 @@
   uri:
     validate_certs: no
     force_basic_auth: yes
-    url: https://{{ client_cluster_hostname }}:{{ client_cluster_gui_port }}/{{ remote_mount_endpoint }}/remotefilesystems/{{ client_filesystem_name }}
+    url: https://{{ client_cluster_gui_hostname }}:{{ client_cluster_gui_port }}/{{ remote_mount_endpoint }}/remotefilesystems/{{ client_filesystem_name }}
     method: GET
     user: "{{ client_cluster_gui_username }}"
     password: "{{ client_cluster_gui_password }}"

--- a/roles/core/remote_mount/tasks/main.yml
+++ b/roles/core/remote_mount/tasks/main.yml
@@ -10,8 +10,8 @@
     force_basic_auth: yes
     url: https://{{ client_cluster_hostname }}:{{ client_cluster_gui_port }}/{{ remote_mount_endpoint }}/remotefilesystems/{{ client_filesystem_name }}
     method: GET
-    user: "{{ client_gui_user }}"
-    password: "{{ client_gui_password }}"
+    user: "{{ client_cluster_gui_username }}"
+    password: "{{ client_cluster_gui_password }}"
     body_format: json
     status_code:
       - 400

--- a/roles/core/remote_mount/tasks/main.yml
+++ b/roles/core/remote_mount/tasks/main.yml
@@ -4,11 +4,11 @@
 - name: precheck
   include_tasks: precheck.yml
 
-- name: "Client Cluster (access) | Check if the '{{ client_filesystem_name }}' is already configured."
+- name: "Client Cluster (access) | Check if the '{{ client_cluster_filesystem_name }}' is already configured."
   uri:
     validate_certs: no
     force_basic_auth: yes
-    url: https://{{ client_cluster_gui_hostname }}:{{ client_cluster_gui_port }}/{{ remote_mount_endpoint }}/remotefilesystems/{{ client_filesystem_name }}
+    url: https://{{ client_cluster_gui_hostname }}:{{ client_cluster_gui_port }}/{{ remote_mount_endpoint }}/remotefilesystems/{{ client_cluster_filesystem_name }}
     method: GET
     user: "{{ client_cluster_gui_username }}"
     password: "{{ client_cluster_gui_password }}"
@@ -35,7 +35,7 @@
 - block:
     - name: "If filesystem is already configured, nothing to do."
       debug:
-        msg: "Filesystem '{{ client_filesystem_name }}' is already configured, nothing to do."
+        msg: "Filesystem '{{ client_cluster_filesystem_name }}' is already configured, nothing to do."
 
     - meta: end_play
   when:

--- a/roles/core/remote_mount/tasks/mount_filesystem.yml
+++ b/roles/core/remote_mount/tasks/mount_filesystem.yml
@@ -26,8 +26,8 @@
     force_basic_auth: yes
     url: https://{{ client_cluster_hostname }}:{{ client_cluster_gui_port }}/{{ scalemgmt_endpoint }}/cluster
     method: GET
-    user: "{{ client_gui_user }}"
-    password: "{{ client_gui_password }}"
+    user: "{{ client_cluster_gui_username }}"
+    password: "{{ client_cluster_gui_password }}"
     body_format: json
     status_code:
       - 200
@@ -105,8 +105,8 @@
     force_basic_auth: yes
     url: https://{{ client_cluster_hostname }}:{{ client_cluster_gui_port }}/{{ remote_mount_endpoint }}/authenticationkey
     method: GET
-    user: "{{ client_gui_user }}"
-    password: "{{ client_gui_password }}"
+    user: "{{ client_cluster_gui_username }}"
+    password: "{{ client_cluster_gui_password }}"
     body_format: json
     status_code:
       - 200
@@ -123,8 +123,8 @@
     force_basic_auth: true
     url: https://{{ storage_cluster_gui_hostname }}:{{ storage_cluster_gui_port }}/{{ remote_mount_endpoint }}/remoteclusters
     method: POST
-    user: "{{ storage_gui_user }}"
-    password: "{{ storage_gui_password }}"
+    user: "{{ storage_cluster_gui_user }}"
+    password: "{{ storage_cluster_gui_password }}"
     body_format: json
     body: |
       {
@@ -141,8 +141,8 @@
     force_basic_auth: true
     url: https://{{ storage_cluster_gui_hostname }}:{{ storage_cluster_gui_port }}/{{ scalemgmt_endpoint }}/jobs/{{ send_key.json.jobs[0].jobId }}
     method: GET
-    user: "{{ storage_gui_user }}"
-    password: "{{ storage_gui_password }}"
+    user: "{{ storage_cluster_gui_user }}"
+    password: "{{ storage_cluster_gui_password }}"
   register: completed_check
   until: completed_check.json.jobs[0].status != "FAILED"
   retries: "{{ restapi_retries_count }}"
@@ -157,8 +157,8 @@
     force_basic_auth: yes
     url: https://{{ client_cluster_hostname }}:{{ client_cluster_gui_port }}/{{ remote_mount_endpoint }}/remoteclusters/{{ owning_cluster_name }}
     method: GET
-    user: "{{ client_gui_user }}"
-    password: "{{ client_gui_password }}"
+    user: "{{ client_cluster_gui_username }}"
+    password: "{{ client_cluster_gui_password }}"
     body_format: json
     status_code:
       - 200
@@ -173,8 +173,8 @@
         force_basic_auth: true
         url: https://{{ client_cluster_hostname }}:{{ client_cluster_gui_port }}/{{ remote_mount_endpoint }}/remoteclusters/{{ owning_cluster_name }}
         method: DELETE
-        user: "{{ client_gui_user }}"
-        password: "{{ client_gui_password }}"
+        user: "{{ client_cluster_gui_username }}"
+        password: "{{ client_cluster_gui_password }}"
         status_code:
           - 202
       register: delete_call
@@ -185,8 +185,8 @@
         force_basic_auth: true
         url: https://{{ client_cluster_hostname }}:{{ client_cluster_gui_port }}/{{ scalemgmt_endpoint }}/jobs/{{ delete_call.json.jobs[0].jobId }}
         method: GET
-        user: "{{ client_gui_user }}"
-        password: "{{ client_gui_password }}"
+        user: "{{ client_cluster_gui_username }}"
+        password: "{{ client_cluster_gui_password }}"
       register: completed_check
       until: completed_check.json.jobs[0].status == "COMPLETED"
       retries: "{{ restapi_retries_count }}"
@@ -221,8 +221,8 @@
     force_basic_auth: true
     url: https://{{ client_cluster_hostname }}:{{ client_cluster_gui_port }}/{{ remote_mount_endpoint }}/owningclusters
     method: GET
-    user: "{{ client_gui_user }}"
-    password: "{{ client_gui_password }}"
+    user: "{{ client_cluster_gui_username }}"
+    password: "{{ client_cluster_gui_password }}"
   register: remote_clusters_result
 
 - name: DEBUG | Print out the remote clusters
@@ -268,8 +268,8 @@
     force_basic_auth: true
     url: https://{{ client_cluster_hostname }}:{{ client_cluster_gui_port }}/{{ remote_mount_endpoint }}/owningclusters
     method: POST
-    user: "{{ client_gui_user }}"
-    password: "{{ client_gui_password }}"
+    user: "{{ client_cluster_gui_username }}"
+    password: "{{ client_cluster_gui_password }}"
     body_format: json
     body: |
       {
@@ -287,8 +287,8 @@
     force_basic_auth: true
     url: https://{{ client_cluster_hostname }}:{{ client_cluster_gui_port }}/{{ scalemgmt_endpoint }}/jobs/{{ uri_result.json.jobs[0].jobId }}
     method: GET
-    user: "{{ client_gui_user }}"
-    password: "{{ client_gui_password }}"
+    user: "{{ client_cluster_gui_username }}"
+    password: "{{ client_cluster_gui_password }}"
   register: completed_check
   until: completed_check.json.jobs[0].status == "COMPLETED"
   retries: "{{ restapi_retries_count }}"
@@ -338,8 +338,8 @@
     force_basic_auth: true
     url: https://{{ client_cluster_hostname }}:{{ client_cluster_gui_port }}/{{ remote_mount_endpoint }}/remotefilesystems
     method: POST
-    user: "{{ client_gui_user }}"
-    password: "{{ client_gui_password }}"
+    user: "{{ client_cluster_gui_username }}"
+    password: "{{ client_cluster_gui_password }}"
     body_format: json
     body: |
       {
@@ -361,8 +361,8 @@
     force_basic_auth: true
     url: https://{{ client_cluster_hostname }}:{{ client_cluster_gui_port }}/{{ scalemgmt_endpoint }}/jobs/{{ send_key.json.jobs[0].jobId }}
     method: GET
-    user: "{{ client_gui_user }}"
-    password: "{{ client_gui_password }}"
+    user: "{{ client_cluster_gui_username }}"
+    password: "{{ client_cluster_gui_password }}"
   register: completed_check
   until: completed_check.json.jobs[0].status == "COMPLETED"
   retries: "{{ restapi_retries_count }}"

--- a/roles/core/remote_mount/tasks/mount_filesystem.yml
+++ b/roles/core/remote_mount/tasks/mount_filesystem.yml
@@ -343,7 +343,7 @@
     body_format: json
     body: |
       {
-        "remoteFilesystem": "{{ client_filesystem_name }}",
+        "remoteFilesystem": "{{ client_cluster_filesystem_name }}",
         "owningFilesystem": "{{ storage_cluster_filesystem_name }}",
         "owningCluster": "{{ owning_cluster_name }}",
         "remoteMountPath": "{{ client_cluster_remotemount_path | realpath }}",

--- a/roles/core/remote_mount/tasks/mount_filesystem.yml
+++ b/roles/core/remote_mount/tasks/mount_filesystem.yml
@@ -24,7 +24,7 @@
   uri:
     validate_certs: no
     force_basic_auth: yes
-    url: https://{{ client_cluster_hostname }}:{{ client_cluster_gui_port }}/{{ scalemgmt_endpoint }}/cluster
+    url: https://{{ client_cluster_gui_hostname }}:{{ client_cluster_gui_port }}/{{ scalemgmt_endpoint }}/cluster
     method: GET
     user: "{{ client_cluster_gui_username }}"
     password: "{{ client_cluster_gui_password }}"
@@ -103,7 +103,7 @@
   uri:
     validate_certs: no
     force_basic_auth: yes
-    url: https://{{ client_cluster_hostname }}:{{ client_cluster_gui_port }}/{{ remote_mount_endpoint }}/authenticationkey
+    url: https://{{ client_cluster_gui_hostname }}:{{ client_cluster_gui_port }}/{{ remote_mount_endpoint }}/authenticationkey
     method: GET
     user: "{{ client_cluster_gui_username }}"
     password: "{{ client_cluster_gui_password }}"
@@ -155,7 +155,7 @@
   uri:
     validate_certs: no
     force_basic_auth: yes
-    url: https://{{ client_cluster_hostname }}:{{ client_cluster_gui_port }}/{{ remote_mount_endpoint }}/remoteclusters/{{ owning_cluster_name }}
+    url: https://{{ client_cluster_gui_hostname }}:{{ client_cluster_gui_port }}/{{ remote_mount_endpoint }}/remoteclusters/{{ owning_cluster_name }}
     method: GET
     user: "{{ client_cluster_gui_username }}"
     password: "{{ client_cluster_gui_password }}"
@@ -171,7 +171,7 @@
       uri:
         validate_certs: no
         force_basic_auth: true
-        url: https://{{ client_cluster_hostname }}:{{ client_cluster_gui_port }}/{{ remote_mount_endpoint }}/remoteclusters/{{ owning_cluster_name }}
+        url: https://{{ client_cluster_gui_hostname }}:{{ client_cluster_gui_port }}/{{ remote_mount_endpoint }}/remoteclusters/{{ owning_cluster_name }}
         method: DELETE
         user: "{{ client_cluster_gui_username }}"
         password: "{{ client_cluster_gui_password }}"
@@ -183,7 +183,7 @@
       uri:
         validate_certs: no
         force_basic_auth: true
-        url: https://{{ client_cluster_hostname }}:{{ client_cluster_gui_port }}/{{ scalemgmt_endpoint }}/jobs/{{ delete_call.json.jobs[0].jobId }}
+        url: https://{{ client_cluster_gui_hostname }}:{{ client_cluster_gui_port }}/{{ scalemgmt_endpoint }}/jobs/{{ delete_call.json.jobs[0].jobId }}
         method: GET
         user: "{{ client_cluster_gui_username }}"
         password: "{{ client_cluster_gui_password }}"
@@ -219,7 +219,7 @@
   uri:
     validate_certs: no
     force_basic_auth: true
-    url: https://{{ client_cluster_hostname }}:{{ client_cluster_gui_port }}/{{ remote_mount_endpoint }}/owningclusters
+    url: https://{{ client_cluster_gui_hostname }}:{{ client_cluster_gui_port }}/{{ remote_mount_endpoint }}/owningclusters
     method: GET
     user: "{{ client_cluster_gui_username }}"
     password: "{{ client_cluster_gui_password }}"
@@ -266,7 +266,7 @@
   uri:
     validate_certs: no
     force_basic_auth: true
-    url: https://{{ client_cluster_hostname }}:{{ client_cluster_gui_port }}/{{ remote_mount_endpoint }}/owningclusters
+    url: https://{{ client_cluster_gui_hostname }}:{{ client_cluster_gui_port }}/{{ remote_mount_endpoint }}/owningclusters
     method: POST
     user: "{{ client_cluster_gui_username }}"
     password: "{{ client_cluster_gui_password }}"
@@ -285,7 +285,7 @@
   uri:
     validate_certs: no
     force_basic_auth: true
-    url: https://{{ client_cluster_hostname }}:{{ client_cluster_gui_port }}/{{ scalemgmt_endpoint }}/jobs/{{ uri_result.json.jobs[0].jobId }}
+    url: https://{{ client_cluster_gui_hostname }}:{{ client_cluster_gui_port }}/{{ scalemgmt_endpoint }}/jobs/{{ uri_result.json.jobs[0].jobId }}
     method: GET
     user: "{{ client_cluster_gui_username }}"
     password: "{{ client_cluster_gui_password }}"
@@ -336,7 +336,7 @@
   uri:
     validate_certs: no
     force_basic_auth: true
-    url: https://{{ client_cluster_hostname }}:{{ client_cluster_gui_port }}/{{ remote_mount_endpoint }}/remotefilesystems
+    url: https://{{ client_cluster_gui_hostname }}:{{ client_cluster_gui_port }}/{{ remote_mount_endpoint }}/remotefilesystems
     method: POST
     user: "{{ client_cluster_gui_username }}"
     password: "{{ client_cluster_gui_password }}"
@@ -359,7 +359,7 @@
   uri:
     validate_certs: no
     force_basic_auth: true
-    url: https://{{ client_cluster_hostname }}:{{ client_cluster_gui_port }}/{{ scalemgmt_endpoint }}/jobs/{{ send_key.json.jobs[0].jobId }}
+    url: https://{{ client_cluster_gui_hostname }}:{{ client_cluster_gui_port }}/{{ scalemgmt_endpoint }}/jobs/{{ send_key.json.jobs[0].jobId }}
     method: GET
     user: "{{ client_cluster_gui_username }}"
     password: "{{ client_cluster_gui_password }}"

--- a/roles/core/remote_mount/tasks/mount_filesystem.yml
+++ b/roles/core/remote_mount/tasks/mount_filesystem.yml
@@ -6,10 +6,10 @@
   uri:
     validate_certs: no
     force_basic_auth: yes
-    url: https://{{ storage_cluster_hostname }}:{{ storage_gui_port }}/{{ scalemgmt_endpoint }}/cluster
+    url: https://{{ storage_cluster_gui_hostname }}:{{ storage_cluster_gui_port }}/{{ scalemgmt_endpoint }}/cluster
     method: GET
-    user: "{{ storage_gui_user }}"
-    password: "{{ storage_gui_password }}"
+    user: "{{ storage_cluster_gui_username }}"
+    password: "{{ storage_cluster_gui_password }}"
     body_format: json
     status_code:
       - 200
@@ -24,7 +24,7 @@
   uri:
     validate_certs: no
     force_basic_auth: yes
-    url: https://{{ client_cluster_hostname }}:{{ client_gui_port }}/{{ scalemgmt_endpoint }}/cluster
+    url: https://{{ client_cluster_hostname }}:{{ client_cluster_gui_port }}/{{ scalemgmt_endpoint }}/cluster
     method: GET
     user: "{{ client_gui_user }}"
     password: "{{ client_gui_password }}"
@@ -61,10 +61,10 @@
   uri:
     validate_certs: no
     force_basic_auth: yes
-    url: https://{{ storage_cluster_hostname }}:{{ storage_gui_port }}/{{ remote_mount_endpoint }}/remoteclusters/{{ access_cluster_name }}
+    url: https://{{ storage_cluster_gui_hostname }}:{{ storage_cluster_gui_port }}/{{ remote_mount_endpoint }}/remoteclusters/{{ access_cluster_name }}
     method: GET
-    user: "{{ storage_gui_user }}"
-    password: "{{ storage_gui_password }}"
+    user: "{{ storage_cluster_gui_username }}"
+    password: "{{ storage_cluster_gui_password }}"
     body_format: json
     status_code:
       - 200
@@ -77,10 +77,10 @@
       uri:
         validate_certs: no
         force_basic_auth: true
-        url: https://{{ storage_cluster_hostname }}:{{ storage_gui_port }}/{{ remote_mount_endpoint }}/remoteclusters/{{ access_cluster_name }}
+        url: https://{{ storage_cluster_gui_hostname }}:{{ storage_cluster_gui_port }}/{{ remote_mount_endpoint }}/remoteclusters/{{ access_cluster_name }}
         method: DELETE
-        user: "{{ storage_gui_user }}"
-        password: "{{ storage_gui_password }}"
+        user: "{{ storage_cluster_gui_username }}"
+        password: "{{ storage_cluster_gui_password }}"
         status_code:
           - 202
       register: delete_call
@@ -89,10 +89,10 @@
       uri:
         validate_certs: no
         force_basic_auth: true
-        url: https://{{ storage_cluster_hostname }}:{{ storage_gui_port }}/{{ scalemgmt_endpoint }}/jobs/{{ delete_call.json.jobs[0].jobId }}
+        url: https://{{ storage_cluster_gui_hostname }}:{{ storage_cluster_gui_port }}/{{ scalemgmt_endpoint }}/jobs/{{ delete_call.json.jobs[0].jobId }}
         method: GET
-        user: "{{ storage_gui_user }}"
-        password: "{{ storage_gui_password }}"
+        user: "{{ storage_cluster_gui_username }}"
+        password: "{{ storage_cluster_gui_password }}"
       register: completed_check
       until: completed_check.json.jobs[0].status == "COMPLETED"
       retries: "{{ restapi_retries_count }}"
@@ -103,7 +103,7 @@
   uri:
     validate_certs: no
     force_basic_auth: yes
-    url: https://{{ client_cluster_hostname }}:{{ client_gui_port }}/{{ remote_mount_endpoint }}/authenticationkey
+    url: https://{{ client_cluster_hostname }}:{{ client_cluster_gui_port }}/{{ remote_mount_endpoint }}/authenticationkey
     method: GET
     user: "{{ client_gui_user }}"
     password: "{{ client_gui_password }}"
@@ -121,7 +121,7 @@
   uri:
     validate_certs: no
     force_basic_auth: true
-    url: https://{{ storage_cluster_hostname }}:{{ storage_gui_port }}/{{ remote_mount_endpoint }}/remoteclusters
+    url: https://{{ storage_cluster_gui_hostname }}:{{ storage_cluster_gui_port }}/{{ remote_mount_endpoint }}/remoteclusters
     method: POST
     user: "{{ storage_gui_user }}"
     password: "{{ storage_gui_password }}"
@@ -139,7 +139,7 @@
   uri:
     validate_certs: no
     force_basic_auth: true
-    url: https://{{ storage_cluster_hostname }}:{{ storage_gui_port }}/{{ scalemgmt_endpoint }}/jobs/{{ send_key.json.jobs[0].jobId }}
+    url: https://{{ storage_cluster_gui_hostname }}:{{ storage_cluster_gui_port }}/{{ scalemgmt_endpoint }}/jobs/{{ send_key.json.jobs[0].jobId }}
     method: GET
     user: "{{ storage_gui_user }}"
     password: "{{ storage_gui_password }}"
@@ -155,7 +155,7 @@
   uri:
     validate_certs: no
     force_basic_auth: yes
-    url: https://{{ client_cluster_hostname }}:{{ client_gui_port }}/{{ remote_mount_endpoint }}/remoteclusters/{{ owning_cluster_name }}
+    url: https://{{ client_cluster_hostname }}:{{ client_cluster_gui_port }}/{{ remote_mount_endpoint }}/remoteclusters/{{ owning_cluster_name }}
     method: GET
     user: "{{ client_gui_user }}"
     password: "{{ client_gui_password }}"
@@ -171,7 +171,7 @@
       uri:
         validate_certs: no
         force_basic_auth: true
-        url: https://{{ client_cluster_hostname }}:{{ client_gui_port }}/{{ remote_mount_endpoint }}/remoteclusters/{{ owning_cluster_name }}
+        url: https://{{ client_cluster_hostname }}:{{ client_cluster_gui_port }}/{{ remote_mount_endpoint }}/remoteclusters/{{ owning_cluster_name }}
         method: DELETE
         user: "{{ client_gui_user }}"
         password: "{{ client_gui_password }}"
@@ -183,7 +183,7 @@
       uri:
         validate_certs: no
         force_basic_auth: true
-        url: https://{{ client_cluster_hostname }}:{{ client_gui_port }}/{{ scalemgmt_endpoint }}/jobs/{{ delete_call.json.jobs[0].jobId }}
+        url: https://{{ client_cluster_hostname }}:{{ client_cluster_gui_port }}/{{ scalemgmt_endpoint }}/jobs/{{ delete_call.json.jobs[0].jobId }}
         method: GET
         user: "{{ client_gui_user }}"
         password: "{{ client_gui_password }}"
@@ -197,10 +197,10 @@
   uri:
     validate_certs: no
     force_basic_auth: yes
-    url: https://{{ storage_cluster_hostname }}:{{ storage_gui_port }}/{{ remote_mount_endpoint }}/authenticationkey
+    url: https://{{ storage_cluster_gui_hostname }}:{{ storage_cluster_gui_port }}/{{ remote_mount_endpoint }}/authenticationkey
     method: GET
-    user: "{{ storage_gui_user }}"
-    password: "{{ storage_gui_password }}"
+    user: "{{ storage_cluster_gui_username }}"
+    password: "{{ storage_cluster_gui_password }}"
     body_format: json
     status_code:
       - 200
@@ -219,7 +219,7 @@
   uri:
     validate_certs: no
     force_basic_auth: true
-    url: https://{{ client_cluster_hostname }}:{{ client_gui_port }}/{{ remote_mount_endpoint }}/owningclusters
+    url: https://{{ client_cluster_hostname }}:{{ client_cluster_gui_port }}/{{ remote_mount_endpoint }}/owningclusters
     method: GET
     user: "{{ client_gui_user }}"
     password: "{{ client_gui_password }}"
@@ -241,10 +241,10 @@
   uri:
     validate_certs: no
     force_basic_auth: yes
-    url: https://{{ storage_cluster_hostname }}:{{ storage_gui_port }}/{{ scalemgmt_endpoint }}/nodes
+    url: https://{{ storage_cluster_gui_hostname }}:{{ storage_cluster_gui_port }}/{{ scalemgmt_endpoint }}/nodes
     method: GET
-    user: "{{ storage_gui_user }}"
-    password: "{{ storage_gui_password }}"
+    user: "{{ storage_cluster_gui_username }}"
+    password: "{{ storage_cluster_gui_password }}"
     body_format: json
     status_code:
       - 200
@@ -266,7 +266,7 @@
   uri:
     validate_certs: no
     force_basic_auth: true
-    url: https://{{ client_cluster_hostname }}:{{ client_gui_port }}/{{ remote_mount_endpoint }}/owningclusters
+    url: https://{{ client_cluster_hostname }}:{{ client_cluster_gui_port }}/{{ remote_mount_endpoint }}/owningclusters
     method: POST
     user: "{{ client_gui_user }}"
     password: "{{ client_gui_password }}"
@@ -285,7 +285,7 @@
   uri:
     validate_certs: no
     force_basic_auth: true
-    url: https://{{ client_cluster_hostname }}:{{ client_gui_port }}/{{ scalemgmt_endpoint }}/jobs/{{ uri_result.json.jobs[0].jobId }}
+    url: https://{{ client_cluster_hostname }}:{{ client_cluster_gui_port }}/{{ scalemgmt_endpoint }}/jobs/{{ uri_result.json.jobs[0].jobId }}
     method: GET
     user: "{{ client_gui_user }}"
     password: "{{ client_gui_password }}"
@@ -302,10 +302,10 @@
   uri:
     validate_certs: no
     force_basic_auth: true
-    url: https://{{ storage_cluster_hostname }}:{{ storage_gui_port }}/{{ remote_mount_endpoint }}/remoteclusters/{{ access_cluster_name }}/access/{{ storage_filesystem_name }}
+    url: https://{{ storage_cluster_gui_hostname }}:{{ storage_cluster_gui_port }}/{{ remote_mount_endpoint }}/remoteclusters/{{ access_cluster_name }}/access/{{ storage_cluster_filesystem_name }}
     method: POST
-    user: "{{ storage_gui_user }}"
-    password: "{{ storage_gui_password }}"
+    user: "{{ storage_cluster_gui_username }}"
+    password: "{{ storage_cluster_gui_password }}"
     body_format: json
     body: |
       {
@@ -319,10 +319,10 @@
   uri:
     validate_certs: no
     force_basic_auth: true
-    url: https://{{ storage_cluster_hostname }}:{{ storage_gui_port }}/{{ scalemgmt_endpoint }}/jobs/{{ uri_result.json.jobs[0].jobId }}
+    url: https://{{ storage_cluster_gui_hostname }}:{{ storage_cluster_gui_port }}/{{ scalemgmt_endpoint }}/jobs/{{ uri_result.json.jobs[0].jobId }}
     method: GET
-    user: "{{ storage_gui_user }}"
-    password: "{{ storage_gui_password }}"
+    user: "{{ storage_cluster_gui_username }}"
+    password: "{{ storage_cluster_gui_password }}"
   register: completed_check
   until: completed_check.json.jobs[0].status == "COMPLETED"
   retries: "{{ restapi_retries_count }}"
@@ -336,7 +336,7 @@
   uri:
     validate_certs: no
     force_basic_auth: true
-    url: https://{{ client_cluster_hostname }}:{{ client_gui_port }}/{{ remote_mount_endpoint }}/remotefilesystems
+    url: https://{{ client_cluster_hostname }}:{{ client_cluster_gui_port }}/{{ remote_mount_endpoint }}/remotefilesystems
     method: POST
     user: "{{ client_gui_user }}"
     password: "{{ client_gui_password }}"
@@ -344,9 +344,9 @@
     body: |
       {
         "remoteFilesystem": "{{ client_filesystem_name }}",
-        "owningFilesystem": "{{ storage_filesystem_name }}",
+        "owningFilesystem": "{{ storage_cluster_filesystem_name }}",
         "owningCluster": "{{ owning_cluster_name }}",
-        "remoteMountPath": "{{ client_remotemount_path | realpath }}",
+        "remoteMountPath": "{{ client_cluster_remotemount_path | realpath }}",
         "mountOptions": "{{ access_mount_attributes }}",
         "automount": "yes",
         "mountOnNodes": "all"
@@ -359,7 +359,7 @@
   uri:
     validate_certs: no
     force_basic_auth: true
-    url: https://{{ client_cluster_hostname }}:{{ client_gui_port }}/{{ scalemgmt_endpoint }}/jobs/{{ send_key.json.jobs[0].jobId }}
+    url: https://{{ client_cluster_hostname }}:{{ client_cluster_gui_port }}/{{ scalemgmt_endpoint }}/jobs/{{ send_key.json.jobs[0].jobId }}
     method: GET
     user: "{{ client_gui_user }}"
     password: "{{ client_gui_password }}"

--- a/roles/core/remote_mount/tasks/precheck.yml
+++ b/roles/core/remote_mount/tasks/precheck.yml
@@ -9,10 +9,10 @@
     msg: "client_cluster_gui_password is not defined"
   when: client_cluster_gui_password is undefined
 
-- name: "fail if not defined: client_cluster_hostname"
+- name: "fail if not defined: client_cluster_gui_hostname"
   fail:
-    msg: "client_cluster_hostname is not defined"
-  when: client_cluster_hostname is undefined
+    msg: "client_cluster_gui_hostname is not defined"
+  when: client_cluster_gui_hostname is undefined
 
 - name: "fail if not defined: client_filesystem_name"
   fail:

--- a/roles/core/remote_mount/tasks/precheck.yml
+++ b/roles/core/remote_mount/tasks/precheck.yml
@@ -1,13 +1,13 @@
 ---
-- name: "fail if not defined: client_gui_user"
+- name: "fail if not defined: client_cluster_gui_username"
   fail:
-    msg: "client_gui_user is not defined"
-  when: client_gui_user is undefined
+    msg: "client_cluster_gui_username is not defined"
+  when: client_cluster_gui_username is undefined
 
-- name: "fail if not defined: client_gui_password"
+- name: "fail if not defined: client_cluster_gui_password"
   fail:
-    msg: "client_gui_password is not defined"
-  when: client_gui_password is undefined
+    msg: "client_cluster_gui_password is not defined"
+  when: client_cluster_gui_password is undefined
 
 - name: "fail if not defined: client_cluster_hostname"
   fail:

--- a/roles/core/remote_mount/tasks/precheck.yml
+++ b/roles/core/remote_mount/tasks/precheck.yml
@@ -14,10 +14,10 @@
     msg: "client_cluster_gui_hostname is not defined"
   when: client_cluster_gui_hostname is undefined
 
-- name: "fail if not defined: client_filesystem_name"
+- name: "fail if not defined: client_cluster_filesystem_name"
   fail:
-    msg: "client_filesystem_name is not defined"
-  when: client_filesystem_name is undefined
+    msg: "client_cluster_filesystem_name is not defined"
+  when: client_cluster_filesystem_name is undefined
 
 - name: "fail if not defined: client_cluster_remotemount_path"
   fail:

--- a/roles/core/remote_mount/tasks/precheck.yml
+++ b/roles/core/remote_mount/tasks/precheck.yml
@@ -19,27 +19,27 @@
     msg: "client_filesystem_name is not defined"
   when: client_filesystem_name is undefined
 
-- name: "fail if not defined: client_remotemount_path"
+- name: "fail if not defined: client_cluster_remotemount_path"
   fail:
-    msg: "client_remotemount_path is not defined"
-  when: client_remotemount_path is undefined
+    msg: "client_cluster_remotemount_path is not defined"
+  when: client_cluster_remotemount_path is undefined
 
-- name: "fail if not defined: storage_gui_user"
+- name: "fail if not defined: storage_cluster_gui_username"
   fail:
-    msg: "storage_gui_user is not defined"
-  when: storage_gui_user is undefined
+    msg: "storage_cluster_gui_username is not defined"
+  when: storage_cluster_gui_username is undefined
 
-- name: "fail if not defined: storage_gui_password"
+- name: "fail if not defined: storage_cluster_gui_password"
   fail:
-    msg: "storage_gui_password is not defined"
-  when: storage_gui_password is undefined
+    msg: "storage_cluster_gui_password is not defined"
+  when: storage_cluster_gui_password is undefined
 
-- name: "fail if not defined: storage_cluster_hostname"
+- name: "fail if not defined: storage_cluster_gui_hostname"
   fail:
-    msg: "storage_cluster_hostname is not defined"
-  when: storage_cluster_hostname is undefined
+    msg: "storage_cluster_gui_hostname is not defined"
+  when: storage_cluster_gui_hostname is undefined
 
-- name: "fail if not defined: storage_filesystem_name"
+- name: "fail if not defined: storage_cluster_filesystem_name"
   fail:
-    msg: "storage_filesystem_name is not defined"
-  when: storage_filesystem_name is undefined
+    msg: "storage_cluster_filesystem_name is not defined"
+  when: storage_cluster_filesystem_name is undefined


### PR DESCRIPTION
Testing the following: 

```
git grep "client_gui" 
git grep "storage_gui" 
git grep client_cluster_hostname
git grep storage_cluster_hostname

```